### PR TITLE
fix: add missing dbName variable to mongo environment config

### DIFF
--- a/src/config/environment/environment-config.factory.ts
+++ b/src/config/environment/environment-config.factory.ts
@@ -11,6 +11,7 @@ export const ENVIRONMENT_CONFIGURATION_FACTORY = (): EnvironmentConfig => {
             pass: process.env.MONGO_PASS ?? '',
             uri: process.env.MONGO_URI ?? '',
             user: process.env.MONGO_USER ?? '',
+            dbName: process.env.MONGO_DB ?? '',
         },
     };
 };

--- a/src/config/environment/environment-config.interface.ts
+++ b/src/config/environment/environment-config.interface.ts
@@ -7,5 +7,6 @@ export interface EnvironmentConfig {
         pass: string;
         uri: string;
         user: string;
+        dbName: string;
     };
 }


### PR DESCRIPTION
Add missing variable dbName to mongo's environment configuration